### PR TITLE
added: in-memory h2 database

### DIFF
--- a/rentplace/build.gradle
+++ b/rentplace/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	//testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/rentplace/src/main/resources/application.yaml
+++ b/rentplace/src/main/resources/application.yaml
@@ -2,11 +2,13 @@ spring:
   application:
     name: rentplace
   datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/rentplace_db
-    username: kattsyn
-    password: katt
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test_db;MODE=PostgreSQL
+    username: sa
+    password:
   jpa:
     generate-ddl: true
+    hibernate:
+      ddl-auto: update
 api:
   path: api/v1


### PR DESCRIPTION
1. Добавил в gradle.build зависимость H2 базы данных, работает только в Runtime
2. Сконфигурировал application.yaml на работу с H2 из памяти.

Теперь при запуске и сборке приложения не будет требовать внешний источник данных. До этого был сконфигурирован на работу с PostgreSQL, который нужно было разворачивать, чтобы просто запустить. Также теперь можно писать нормальные unit-тесты с реальными данными из бд.